### PR TITLE
fix(schema.prisma): Remove `shadowDatabaseUrl`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator client {
 datasource db {
     provider          = "postgresql"
     url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
-    shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations}
+    directUrl         = env("POSTGRES_URL_NON_POOLING") // used for migrations}
 }
 
 // Account represents a connection between a user and an OAuth provider


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`